### PR TITLE
Wrap SystemRegistry values in a struct to inspect them.

### DIFF
--- a/lib/system_registry.ex
+++ b/lib/system_registry.ex
@@ -18,6 +18,13 @@ defmodule SystemRegistry do
   alias SystemRegistry.Storage.State, as: S
   import SystemRegistry.Utils
 
+  defstruct [:data]
+  defimpl Inspect, for: SystemRegistry do
+    def inspect(%SystemRegistry{} = _data, _opts) do
+      "#SystemRegistry<[]>"
+    end
+  end
+
   @doc """
     Returns a transaction struct to pass to update/3 and delete/4 to chain
     modifications to to group. Prevents notifying registrants for each action.
@@ -258,7 +265,7 @@ defmodule SystemRegistry do
 
     Examples
 
-      iex> purge_mailbox = fn (self) -> 
+      iex> purge_mailbox = fn (self) ->
       ...>   receive do
       ...>     _ -> self.(self)
       ...>   after
@@ -274,7 +281,7 @@ defmodule SystemRegistry do
       iex> :timer.sleep(50)
       :ok
       iex> Process.info(self())[:messages]
-      [{:system_registry, :global, %{state: %{a: 1}}}]
+      [{:system_registry, :global, %SystemRegistry{data: %{state: %{a: 1}}}}]
       iex> SystemRegistry.unregister()
       :ok
       iex> purge_mailbox.(purge_mailbox)
@@ -291,7 +298,7 @@ defmodule SystemRegistry do
       []
       iex> :timer.sleep(15)
       iex> Process.info(self())[:messages]
-      [{:system_registry, :global, %{state: %{a: 1}}}]
+      [{:system_registry, :global, %SystemRegistry{data: %{state: %{a: 1}}}}]
       iex> purge_mailbox.(purge_mailbox)
       :ok
       iex> SystemRegistry.update([:state, :a], 2)
@@ -301,7 +308,7 @@ defmodule SystemRegistry do
       iex> :timer.sleep(50)
       :ok
       iex> Process.info(self())[:messages]
-      [{:system_registry, :global, %{state: %{a: 2}}}]
+      [{:system_registry, :global, %SystemRegistry{data: %{state: %{a: 2}}}}]
 
   """
   @spec register(opts :: keyword) :: :ok | {:error, term}

--- a/lib/system_registry/registration.ex
+++ b/lib/system_registry/registration.ex
@@ -167,6 +167,6 @@ defmodule SystemRegistry.Registration do
   end
 
   defp notify_reg(%__MODULE__{pid: pid}, key, value) do
-    send(pid, {:system_registry, key, value})
+    send(pid, {:system_registry, key, struct(SystemRegistry, data: value)})
   end
 end


### PR DESCRIPTION
# _THIS IS AN API BREAKING CHANGE_

This cleans up the log barf issue as described [here](https://github.com/nerves-project/nerves_runtime/issues/37)
Unfortunately it has the side effect of breaking existing installations.

I am 100% open to other ideas. 