### PR TITLE
Do not run doctest.

### DIFF
--- a/lib/system_registry.ex
+++ b/lib/system_registry.ex
@@ -266,7 +266,7 @@ defmodule SystemRegistry do
 
   @doc """
   Register process to receive notifications.
- 
+
   Registrants are rate-limited and require that you pass an interval.
   Upon registration, the caller will receive the current state.
 

--- a/test/registration_test.exs
+++ b/test/registration_test.exs
@@ -44,13 +44,13 @@ defmodule SystemRegistry.RegistrationTest do
     SR.register(key: key)
     update = %{root => %{a: 1}}
     SR.update([], update)
-    assert_receive({:system_registry, ^key, ^update}, 10)
+    assert_receive({:system_registry, ^key, ^update}, 20)
   end
 
   test "global notification delivery", %{root: root} do
     SR.register()
     SR.update([], %{state: %{root => %{a: 1}}})
-    assert_receive({:system_registry, :global, %{state: %{^root => %{a: 1}}}}, 10)
+    assert_receive({:system_registry, :global, %{state: %{^root => %{a: 1}}}}, 20)
   end
 
   test "rate limited notification delivery", %{root: root} do
@@ -65,19 +65,19 @@ defmodule SystemRegistry.RegistrationTest do
   test "rate limit of 0 should dispatch every message", %{root: root} do
     SR.register()
     SR.update([], %{state: %{root => %{a: 1}}})
-    assert_receive({:system_registry, :global, %{state: %{^root => %{a: 1}}}}, 10)
+    assert_receive({:system_registry, :global, %{state: %{^root => %{a: 1}}}}, 20)
     SR.update([], %{state: %{root => %{a: 2}}})
-    assert_receive({:system_registry, :global, %{state: %{^root => %{a: 2}}}}, 10)
+    assert_receive({:system_registry, :global, %{state: %{^root => %{a: 2}}}}, 20)
   end
 
   test "hysteresis opts for rate limiting", %{root: root} do
     SR.register(hysteresis: 20, min_interval: 100)
     SR.update([], %{state: %{root => %{a: 1}}})
     refute_receive({:system_registry, :global, %{state: %{^root => %{a: 1}}}}, 10)
-    assert_receive({:system_registry, :global, %{state: %{^root => %{a: 1}}}}, 20)
+    assert_receive({:system_registry, :global, %{state: %{^root => %{a: 1}}}}, 25)
     SR.update([], %{state: %{root => %{a: 2}}})
     refute_receive({:system_registry, :global, %{state: %{^root => %{a: 2}}}}, 50)
-    assert_receive({:system_registry, :global, %{state: %{^root => %{a: 2}}}}, 50)
+    assert_receive({:system_registry, :global, %{state: %{^root => %{a: 2}}}}, 65)
   end
 
   test "notifications on update / delete", %{root: root} do

--- a/test/registration_test.exs
+++ b/test/registration_test.exs
@@ -89,8 +89,9 @@ defmodule SystemRegistry.RegistrationTest do
   end
 
   test "cannot convert an inner node into a leaf node", %{root: root} do
-    update_task([:state, root, :a, :b], 1)
     SR.register()
+    update_task([:state, root, :a, :b], 1)
+    assert_receive({:system_registry, :global, %{state: %{^root => %{a: %{b: 1}}}}})
 
     t =
       SR.transaction(notify_on_error: true)

--- a/test/system_registry_test.exs
+++ b/test/system_registry_test.exs
@@ -1,6 +1,5 @@
 defmodule SystemRegistryTest do
   use SystemRegistryTest.Case
-  doctest SystemRegistry
 
   alias SystemRegistry, as: SR
   alias SystemRegistry.Node

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,6 +4,6 @@ Logger.remove_backend(:console)
 
 Code.compiler_options(ignore_module_conflict: true)
 
-assert_timeout = String.to_integer(System.get_env("ELIXIR_ASSERT_TIMEOUT") || "200")
+assert_timeout = String.to_integer(System.get_env("ELIXIR_ASSERT_TIMEOUT") || "500")
 
 ExUnit.start(assert_receive_timeout: assert_timeout, max_cases: 1)


### PR DESCRIPTION
The doctests have side effects and do not run in a sandbox, therefore, these tests often cause a lot of false positives. This is taken from https://hexdocs.pm/ex_unit/ExUnit.DocTest.html#module-when-not-to-use-doctest